### PR TITLE
Rename hooks to listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ type Options = {
 ```
 ## API
 
-The library contains 3 actors: Middleware, Hooks and Triggers. The different parts of the system are glued together by the Context object.
+The library contains 3 actors: Middleware, Listeners and Triggers. The different parts of the system are glued together by the Context object.
 
 ### Context
 
-The Context is an object that contains the provided options, the provided hooks, and the state updater. The Context object provides everything you need to alter the internals of the library.
+The Context is an object that contains the provided options, the provided listeners, and the state updater. The Context object provides everything you need to alter the internals of the library.
 
 ```ts
 type Context = {
   updater: Updater;
   options: Options;
-  hooks: Hooks;
+  listeners: Listeners;
 };
 ```
 
@@ -97,14 +97,14 @@ const store = async (next, data, action) => {
 };
 ```
 
-### Hooks (final name pending)
+### Listeners
 
-The hooks (not to be confused with React hooks) are callbacks that can be called from within the any Middleware, or Triggers. These are a the appropriate mechanism for sharing the internal library state with the userland application code.
-The library provides some default hooks that are being used by the default middleware and triggers. But the user can extend these to include any other hook that they deem necessary. This is very useful because the user can define a custom middleware that in turn has access to custom hooks.
+The listeners are callbacks that can be called from within the any Middleware, or Triggers. These are the appropriate mechanism for sharing the internal library state with the userland application code.
+The library provides some default listeners that are being used by the default middleware and triggers. But the user can extend these to include any other listener that they deem necessary. This is very useful because the user can define a custom middleware that in turn has access to custom listeners.
 
 ```ts
-export type Hooks = {
-  [customHookName: string]: (...args: any[]) => void;
+export type Listeners = {
+  [customListenerName: string]: (...args: any[]) => void;
   onRequest: (action: Action) => void;
   onCommit: (data: unknown, action: Action['meta']['commit']) => void;
   onRollback: (error: UnknownError, action: Action['meta']['rollback']) => void;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,11 +25,11 @@ const detectNetwork = callback => {
   };
 };
 
-const useOfflineSideEffects = hooks => {
+const useOfflineSideEffects = listeners => {
   const offlineReducer = (_, newState) => ({ ...newState });
   const [persistedState, persist] = usePersistedOutbox(offlineReducer, {});
   const { addSideEffect, setPaused, rehydrateState, restart, reset } = useRef(
-    offlineSideEffects({ ...hooks, onSerialize: persist })
+    offlineSideEffects({ ...listeners, onSerialize: persist })
   ).current;
   const rehydrate = useRef(() => rehydrateState(persistedState)).current;
   return {
@@ -43,14 +43,14 @@ const useOfflineSideEffects = hooks => {
 
 function App() {
   const [state, dispatch] = useAppStateReducer(reducer, initialState);
-  const hooks = {
+  const listeners = {
     onRequest: dispatch,
     onRollback: (error, action) => dispatch({ ...action, payload: error }),
     onCommit: (data, action) => dispatch({ ...action, payload: data }),
     onStatusChange: status => dispatch(toggleBusy(status))
   };
 
-  const { addSideEffect, setPaused, rehydrate } = useOfflineSideEffects(hooks);
+  const { addSideEffect, setPaused, rehydrate } = useOfflineSideEffects(listeners);
 
   useEffect(() => {
     rehydrate();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,27 +1,27 @@
-import { Options, Hooks, Context } from './types';
+import { Options, Listeners, Context } from './types';
 import defaults from './defaults';
 import { createUpdater } from './updater';
 import { createTriggers } from './triggers';
 import { createStream } from './stream';
 
-export const offlineSideEffects = (providedHooks: Partial<Hooks>, providedOptions?: Options) => {
-  const hooks = {
+export const offlineSideEffects = (providedListeners: Partial<Listeners>, providedOptions?: Options) => {
+  const listeners = {
     onRequest: () => {},
     onCommit: () => {},
     onRollback: () => {},
     onStatusChange: () => {},
     onSerialize: () => {},
     onRetry: () => {},
-    ...providedHooks
+    ...providedListeners
   };
   const options = {
     ...defaults,
     ...providedOptions
   };
-  const updater = createUpdater(options, hooks);
+  const updater = createUpdater(options, listeners);
   const context: Context = {
     options,
-    hooks,
+    listeners,
     updater
   };
   const stream = createStream(context);

--- a/src/lib/triggers.ts
+++ b/src/lib/triggers.ts
@@ -1,13 +1,13 @@
 import { Action, Context, Stream, Updates, State } from './types';
 
-export function createTriggers(stream: Stream, { updater, hooks }: Context) {
+export function createTriggers(stream: Stream, { updater, listeners }: Context) {
   const [state, updateState] = updater;
 
   const actionWasRequested = (action: Action) => {
     if (action.meta?.effect) {
       const request = { ...action };
       updateState(Updates.enqueue, request);
-      hooks.onRequest(request);
+      listeners.onRequest(request);
     }
     stream.start();
   };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,8 +44,8 @@ export type RetryMiddleware = Middleware<[UnknownError, Action], undefined[]>;
 
 export type DefaultMiddlewareChain = [ProcessOutboxMiddleware, SendMiddleware, RetryMiddleware];
 
-export type Hooks = {
-  [customHookName: string]: (...args: any[]) => void;
+export type Listeners = {
+  [customListenersName: string]: (...args: any[]) => void;
   onRequest: (action: Action) => void;
   onCommit: (data: unknown, action: Action['meta']['commit']) => void;
   onRollback: (error: UnknownError, action: Action['meta']['rollback']) => void;
@@ -61,7 +61,7 @@ export type Stream = {
 export type Context = {
   updater: Updater;
   options: Options;
-  hooks: Hooks;
+  listeners: Listeners;
 };
 
 export type Options = {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,4 +1,4 @@
-import { State, UpdateState, Updater, Updates, Options, Hooks, Action } from './types';
+import { State, UpdateState, Updater, Updates, Options, Listeners, Action } from './types';
 
 const initialState: State = {
   outbox: [],
@@ -8,7 +8,7 @@ const initialState: State = {
   lastTransaction: 0
 };
 
-export const createUpdater = (options: Options, hooks: Hooks): Updater => {
+export const createUpdater = (options: Options, listeners: Listeners): Updater => {
   const state = { ...initialState };
   const updateState: UpdateState = (type: Updates, payload = null) => {
     if (type === Updates.rehydrate) {
@@ -47,7 +47,7 @@ export const createUpdater = (options: Options, hooks: Hooks): Updater => {
       Object.assign(state, initialState);
     }
 
-    hooks.onSerialize(state);
+    listeners.onSerialize(state);
   };
 
   return [state, updateState];


### PR DESCRIPTION
This PR renames hooks to listeners because React Hooks might confuse with internal hooks concept. So now in lieau of a better term we're calling them listeners.